### PR TITLE
Supply full URL instead of param bits.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,15 +5,13 @@ const Stream = require('stream');
 
 const Stringify = require('fast-safe-stringify');
 const Logstash = require('logstash-client');
-
+const Url = require('url');
 
 // Declare internals
 
 const internals = {
     defaults: {
-        type: 'tcp',
-        endpoint: 'localhost',
-        port: 8008
+        url: 'tcp://localhost:8008'
     }
 };
 
@@ -23,11 +21,12 @@ class GoodLogstash extends Stream.Writable {
         config = config || {};
         const settings = Object.assign({}, internals.defaults, config);
 
+        const url = Url.parse(settings.url);
         super({ objectMode: true, decodeStrings: false });
         this._client = new Logstash({
-            type: settings.type,
-            host: settings.host,
-            port: settings.port,
+            type: url.protocol.replace(':', ''),
+            host: url.hostname,
+            port: url.port,
             format: (message) => Stringify(message)
         });
 


### PR DESCRIPTION
Helps with parameterising it later + simply using ENV.

I'm not too sure about the `type: url.protocol.replace(':', '')` bit, but I didn't want to go down the https://github.com/nodejs/node-v0.x-archive/pull/1580 path again :grinning: 
