### PR TITLE
Fix 'finish' behavior

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,9 @@ class GoodLogstash extends Stream.Writable {
 
         this.once('finish', () => {
 
+            if (this._client.transport && this._client.transport.close) {
+                this._client.transport.close();
+            }
         });
     }
     _write(data, encoding, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,6 @@ class GoodLogstash extends Stream.Writable {
 
         this.once('finish', () => {
 
-            this._write();
         });
     }
     _write(data, encoding, callback) {


### PR DESCRIPTION
Currently, this module throws when closing the server due to passing empty parameters to `this._write()`.

I have fixed this, and further enhanced the code to actually try to close the underlying transport.