### PR TITLE
Updates to allow Hapi v17 / good v8 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ class GoodLogstash extends Stream.Writable {
       }
     })
   }
-  
+
   _write (data, encoding, callback) {
     this._client.send(data, callback)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,335 @@
 {
   "name": "good-logstash",
-  "version": "3.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "backoff": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
       "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "boom": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
+      "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.3"
+      }
+    },
+    "bossy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bossy/-/bossy-4.0.1.tgz",
+      "integrity": "sha512-IrXZdXnDrjfk9ZVtnnmehlcTGK/KRqUJuNZJteMGU2/cJdXC6yWf2yhkAAbAgjOTsJJHXdlYloTeFH1ZgRNllw==",
+      "dev": true,
+      "requires": {
+        "boom": "7.2.0",
+        "hoek": "5.0.3",
+        "joi": "13.1.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/code/-/code-5.2.0.tgz",
+      "integrity": "sha512-Ul69Vhv+L/sewD9azem9xvj6W+dW7XJ6UYust04KDEYQwyCb9M3ZkUjS7udFNSdvnYvbokBYDoXQXUg0P4DN5g==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.3"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -17,1863 +339,595 @@
         "ms": "2.0.0"
       }
     },
-    "fast-safe-stringify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.1.tgz",
-      "integrity": "sha512-g2UqeO0yyYjTSpiH4zJQk+IycRxyYRABjSf+TpmeMOn9uByzFIoX0y/HnweCFhKb+uuPwjIvqXuK/LTteEBhow=="
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
-    "lab": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-11.0.1.tgz",
-      "integrity": "sha1-VeOtt3XO4vYC4AuRXuupwNcGU0c=",
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "bossy": "3.0.1",
-        "diff": "2.2.3",
-        "eslint": "3.3.1",
-        "eslint-config-hapi": "10.0.0",
-        "eslint-plugin-hapi": "4.0.0",
-        "espree": "3.2.0",
-        "find-rc": "3.0.1",
-        "handlebars": "4.0.5",
-        "hoek": "4.0.2",
-        "items": "2.1.1",
-        "json-stable-stringify": "1.0.1",
-        "json-stringify-safe": "5.0.1",
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.2",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.4.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.11.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.2"
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
       },
       "dependencies": {
-        "bossy": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.1.tgz",
-          "integrity": "sha1-hac0SLPCMJUNJBmZbl6jDXA6Qyw=",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "hoek": "4.0.2",
-            "joi": "9.0.4"
-          },
-          "dependencies": {
-            "joi": {
-              "version": "9.0.4",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-9.0.4.tgz",
-              "integrity": "sha1-iNZIkJFavrEnzXVwJxFtUN8+aN8=",
-              "dev": true,
-              "requires": {
-                "hoek": "4.0.2",
-                "isemail": "2.2.1",
-                "items": "2.1.1",
-                "moment": "2.15.0",
-                "topo": "2.0.2"
-              },
-              "dependencies": {
-                "isemail": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-                  "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
-                  "dev": true
-                },
-                "moment": {
-                  "version": "2.15.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz",
-                  "integrity": "sha1-zJ4zlYv0qZ3qcRHV5i7TwT/JZEA=",
-                  "dev": true
-                },
-                "topo": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-                  "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "4.0.2"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "diff": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-          "dev": true
-        },
-        "eslint": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.3.1.tgz",
-          "integrity": "sha1-7UujS+F14ihskKQv9ja/XibVCWg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.5.2",
-            "debug": "2.2.0",
-            "doctrine": "1.4.0",
-            "escope": "3.6.0",
-            "espree": "3.2.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "7.0.6",
-            "globals": "9.10.0",
-            "ignore": "3.1.5",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.14.0",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.6.1",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.16.0",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.1",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.2",
-            "shelljs": "0.6.1",
-            "strip-bom": "3.0.0",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.0",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                  "dev": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "dev": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                  "dev": true
-                }
-              }
-            },
-            "concat-stream": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-              "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                      "dev": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                  "dev": true
-                }
-              }
-            },
-            "doctrine": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.4.0.tgz",
-              "integrity": "sha1-4tsy3vp1JAe5NbOB6J83QORp5Zk=",
-              "dev": true,
-              "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
-              },
-              "dependencies": {
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
-                }
-              }
-            },
-            "escope": {
-              "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-              "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-              "dev": true,
-              "requires": {
-                "es6-map": "0.1.4",
-                "es6-weak-map": "2.0.1",
-                "esrecurse": "4.1.0",
-                "estraverse": "4.2.0"
-              },
-              "dependencies": {
-                "es6-map": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-                  "integrity": "sha1-o0sUe+IkdzpNfagHJ5TO+jYyuJc=",
-                  "dev": true,
-                  "requires": {
-                    "d": "0.1.1",
-                    "es5-ext": "0.10.12",
-                    "es6-iterator": "2.0.0",
-                    "es6-set": "0.1.4",
-                    "es6-symbol": "3.1.0",
-                    "event-emitter": "0.3.4"
-                  },
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                      "dev": true,
-                      "requires": {
-                        "es5-ext": "0.10.12"
-                      }
-                    },
-                    "es5-ext": {
-                      "version": "0.10.12",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-                      "dev": true,
-                      "requires": {
-                        "es6-iterator": "2.0.0",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-set": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-                      "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12",
-                        "es6-iterator": "2.0.0",
-                        "es6-symbol": "3.1.0",
-                        "event-emitter": "0.3.4"
-                      }
-                    },
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      }
-                    },
-                    "event-emitter": {
-                      "version": "0.3.4",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-                      "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      }
-                    }
-                  }
-                },
-                "es6-weak-map": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-                  "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-                  "dev": true,
-                  "requires": {
-                    "d": "0.1.1",
-                    "es5-ext": "0.10.12",
-                    "es6-iterator": "2.0.0",
-                    "es6-symbol": "3.1.0"
-                  },
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                      "dev": true,
-                      "requires": {
-                        "es5-ext": "0.10.12"
-                      }
-                    },
-                    "es5-ext": {
-                      "version": "0.10.12",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-                      "dev": true,
-                      "requires": {
-                        "es6-iterator": "2.0.0",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      }
-                    }
-                  }
-                },
-                "esrecurse": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-                  "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-                  "dev": true,
-                  "requires": {
-                    "estraverse": "4.1.1",
-                    "object-assign": "4.1.0"
-                  },
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "4.1.1",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-                      "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-                      "dev": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-              "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-              "dev": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-              "dev": true
-            },
-            "file-entry-cache": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
-              "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-              "dev": true,
-              "requires": {
-                "flat-cache": "1.2.1",
-                "object-assign": "4.1.0"
-              },
-              "dependencies": {
-                "flat-cache": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz",
-                  "integrity": "sha1-bIN9YiWn3lZZMjdAs21TYfcWkf8=",
-                  "dev": true,
-                  "requires": {
-                    "circular-json": "0.3.1",
-                    "del": "2.2.2",
-                    "graceful-fs": "4.1.6",
-                    "write": "0.2.1"
-                  },
-                  "dependencies": {
-                    "circular-json": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-                      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
-                      "dev": true
-                    },
-                    "del": {
-                      "version": "2.2.2",
-                      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-                      "dev": true,
-                      "requires": {
-                        "globby": "5.0.0",
-                        "is-path-cwd": "1.0.0",
-                        "is-path-in-cwd": "1.0.0",
-                        "object-assign": "4.1.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "rimraf": "2.5.4"
-                      },
-                      "dependencies": {
-                        "globby": {
-                          "version": "5.0.0",
-                          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-                          "dev": true,
-                          "requires": {
-                            "array-union": "1.0.2",
-                            "arrify": "1.0.1",
-                            "glob": "7.0.6",
-                            "object-assign": "4.1.0",
-                            "pify": "2.3.0",
-                            "pinkie-promise": "2.0.1"
-                          },
-                          "dependencies": {
-                            "array-union": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                              "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-                              "dev": true,
-                              "requires": {
-                                "array-uniq": "1.0.3"
-                              },
-                              "dependencies": {
-                                "array-uniq": {
-                                  "version": "1.0.3",
-                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                                  "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "arrify": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "is-path-cwd": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-                          "dev": true
-                        },
-                        "is-path-in-cwd": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                          "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-                          "dev": true,
-                          "requires": {
-                            "is-path-inside": "1.0.0"
-                          },
-                          "dependencies": {
-                            "is-path-inside": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                              "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                              "dev": true,
-                              "requires": {
-                                "path-is-inside": "1.0.2"
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "2.0.4"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "rimraf": {
-                          "version": "2.5.4",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-                          "dev": true,
-                          "requires": {
-                            "glob": "7.0.6"
-                          }
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.6",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-                      "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
-                      "dev": true
-                    },
-                    "write": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                      "dev": true,
-                      "requires": {
-                        "mkdirp": "0.5.1"
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                  "dev": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.0.6",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-              "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.5",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                  "dev": true
-                },
-                "inflight": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                  "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
-                  "dev": true,
-                  "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "1.1.6"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
-                  "dev": true
-                }
-              }
-            },
-            "globals": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-9.10.0.tgz",
-              "integrity": "sha1-0QR2QcSbewPKz34V+4pCo9M8iPc=",
-              "dev": true
-            },
-            "ignore": {
-              "version": "3.1.5",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.5.tgz",
-              "integrity": "sha1-VLoeuS75//jUnlofsjlhzbp363o=",
-              "dev": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-              "dev": true
-            },
-            "inquirer": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-              "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-              "dev": true,
-              "requires": {
-                "ansi-escapes": "1.4.0",
-                "ansi-regex": "2.0.0",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.1.0",
-                "figures": "1.7.0",
-                "lodash": "4.16.0",
-                "readline2": "1.0.1",
-                "run-async": "0.1.0",
-                "rx-lite": "3.1.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-              },
-              "dependencies": {
-                "ansi-escapes": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-                  "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-                  "dev": true
-                },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                },
-                "cli-cursor": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                  "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-                  "dev": true,
-                  "requires": {
-                    "restore-cursor": "1.0.1"
-                  },
-                  "dependencies": {
-                    "restore-cursor": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                      "dev": true,
-                      "requires": {
-                        "exit-hook": "1.1.1",
-                        "onetime": "1.1.0"
-                      },
-                      "dependencies": {
-                        "exit-hook": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-                          "dev": true
-                        },
-                        "onetime": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cli-width": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-                  "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-                  "dev": true
-                },
-                "figures": {
-                  "version": "1.7.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                  "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-                  "dev": true,
-                  "requires": {
-                    "escape-string-regexp": "1.0.5",
-                    "object-assign": "4.1.0"
-                  },
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                      "dev": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                      "dev": true
-                    }
-                  }
-                },
-                "readline2": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-                  "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.0.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "mute-stream": "0.0.5"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                      "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "mute-stream": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-                      "dev": true
-                    }
-                  }
-                },
-                "run-async": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                  "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-                  "dev": true,
-                  "requires": {
-                    "once": "1.4.0"
-                  },
-                  "dependencies": {
-                    "once": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "rx-lite": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-                  "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.0.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                      "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-                  "dev": true
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
-              "integrity": "sha1-R7+Ahgmy311IyWnHS+zQn7ygJyU=",
-              "dev": true,
-              "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "2.0.0",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                  "dev": true
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                  "dev": true,
-                  "requires": {
-                    "is-property": "1.0.2"
-                  },
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                      "dev": true
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                  "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
-                  "dev": true
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                  "dev": true
-                }
-              }
-            },
-            "is-resolvable": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-              "dev": true,
-              "requires": {
-                "tryit": "1.0.2"
-              },
-              "dependencies": {
-                "tryit": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
-                  "integrity": "sha1-wZawBz5rHFldk8nIMIVbeswypFM=",
-                  "dev": true
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-              "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-              "dev": true,
-              "requires": {
-                "argparse": "1.0.7",
-                "esprima": "2.7.3"
-              },
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-                  "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
-                  "dev": true,
-                  "requires": {
-                    "sprintf-js": "1.0.3"
-                  },
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                      "dev": true
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                  "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-                  "dev": true
-                }
-              }
-            },
-            "levn": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-              "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              },
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                  "dev": true
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "1.1.2"
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "4.16.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.0.tgz",
-              "integrity": "sha1-g0y3hQVxVwMiQr6vEBuz2Z5V0Ng=",
-              "dev": true
-            },
-            "natural-compare": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-              "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-              "dev": true
-            },
-            "optionator": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-              "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
-              "dev": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "1.1.4",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              },
-              "dependencies": {
-                "deep-is": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-                  "dev": true
-                },
-                "fast-levenshtein": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
-                  "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
-                  "dev": true
-                },
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                  "dev": true
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "1.1.2"
-                  }
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                  "dev": true
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-              "dev": true
-            },
-            "pluralize": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-              "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-              "dev": true
-            },
-            "progress": {
-              "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-              "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-              "dev": true
-            },
-            "require-uncached": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
-              "integrity": "sha1-Z9rTtzMInncDASRnikWVifr2p+w=",
-              "dev": true,
-              "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
-              },
-              "dependencies": {
-                "caller-path": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-                  "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-                  "dev": true,
-                  "requires": {
-                    "callsites": "0.2.0"
-                  },
-                  "dependencies": {
-                    "callsites": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                      "dev": true
-                    }
-                  }
-                },
-                "resolve-from": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-                  "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-                  "dev": true
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-              "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
-              "dev": true
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-              "dev": true
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-              "dev": true
-            },
-            "table": {
-              "version": "3.8.0",
-              "resolved": "https://registry.npmjs.org/table/-/table-3.8.0.tgz",
-              "integrity": "sha1-JSFmx/MoZoSp1WGw86iSnK86mXs=",
-              "dev": true,
-              "requires": {
-                "ajv": "4.7.1",
-                "ajv-keywords": "1.0.0",
-                "chalk": "1.1.3",
-                "lodash": "4.16.0",
-                "slice-ansi": "0.0.4",
-                "string-width": "1.0.2"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "4.7.1",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.7.1.tgz",
-                  "integrity": "sha1-e+oN9LmMbM5fErZUlvM/pEibdRM=",
-                  "dev": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "json-stable-stringify": "1.0.1"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                      "dev": true
-                    }
-                  }
-                },
-                "ajv-keywords": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.0.0.tgz",
-                  "integrity": "sha1-PcRhs+8I+HJCZXQZsGI2m9dY3Y0=",
-                  "dev": true
-                },
-                "slice-ansi": {
-                  "version": "0.0.4",
-                  "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-                  "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.0.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                      "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-              "dev": true
-            },
-            "user-home": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-              "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-              "dev": true,
-              "requires": {
-                "os-homedir": "1.0.1"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                  "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "eslint-config-hapi": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.0.0.tgz",
-          "integrity": "sha1-mYCv/XYQPrwf7JK0Vjg0XbGTSPU=",
-          "dev": true
-        },
-        "eslint-plugin-hapi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
-          "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
-          "dev": true,
-          "requires": {
-            "hapi-capitalize-modules": "1.1.6",
-            "hapi-for-you": "1.0.0",
-            "hapi-scope-start": "2.1.1",
-            "no-arrowception": "1.0.0"
-          },
-          "dependencies": {
-            "hapi-capitalize-modules": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
-              "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
-              "dev": true
-            },
-            "hapi-for-you": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
-              "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
-              "dev": true
-            },
-            "hapi-scope-start": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
-              "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
-              "dev": true
-            },
-            "no-arrowception": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
-              "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
-              "dev": true
-            }
-          }
-        },
-        "espree": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.2.0.tgz",
-          "integrity": "sha1-+Z4YIHwiD0xMP4iiKrP/gJrQaSM=",
-          "dev": true,
-          "requires": {
-            "acorn": "4.0.3",
-            "acorn-jsx": "3.0.1"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-              "integrity": "sha1-Gj6FC0KOc7prCdHMUn9aqtTQPvE=",
-              "dev": true
-            },
-            "acorn-jsx": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-              "dev": true,
-              "requires": {
-                "acorn": "3.3.0"
-              },
-              "dependencies": {
-                "acorn": {
-                  "version": "3.3.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                  "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "find-rc": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
-          "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-          "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.7.3"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-              "dev": true
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-                  "dev": true
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-                  "dev": true
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.0"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-                  "dev": true
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
-              "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-                  "dev": true,
-                  "optional": true
-                },
-                "source-map": {
-                  "version": "0.5.6",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-                  "dev": true,
-                  "optional": true
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-                  "dev": true,
-                  "optional": true
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
-                    "window-size": "0.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
-                        "wordwrap": "0.0.2"
-                      },
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "align-text": "0.1.4",
-                            "lazy-cache": "1.0.4"
-                          },
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "kind-of": "3.0.4",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.5.4"
-                              },
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.4",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-                                  "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "is-buffer": "1.1.4"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.4",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                  "dev": true,
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.4",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "align-text": "0.1.4"
-                          },
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "kind-of": "3.0.4",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.5.4"
-                              },
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.4",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-                                  "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "is-buffer": "1.1.4"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.4",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                  "dev": true,
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "hoek": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.2.tgz",
-          "integrity": "sha1-e5afTIoa+KOMosZmxmv6bEL+LN0=",
-          "dev": true
-        },
-        "items": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-          "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
-          "dev": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          },
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
-            }
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "source-map-support": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.2.tgz",
-          "integrity": "sha1-BxDcUxVAHgvtvgiZobuTitvALVs=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.0"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-                  "dev": true
-                }
-              }
-            }
+            "ms": "2.0.0"
           }
         }
       }
+    },
+    "eslint-config-hapi": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-11.1.0.tgz",
+      "integrity": "sha512-fCw0uLgkZLQBqYu/lR5MA6cXB+D4c2EEtzrVmhHbGQq3iRCFSaUEOE/N4Sujd1Qh5jkaUc0/kuB/gdv2upt5aQ==",
+      "dev": true
+    },
+    "eslint-plugin-hapi": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.1.0.tgz",
+      "integrity": "sha512-z1yUoSWArx6pXaC0FoWRFpqjbHn8QWonJiTVhJmiC14jOAT7FZKdKWCkhM4jQrgrkEK9YEv3p2HuzSf5dtWmuQ==",
+      "dev": true,
+      "requires": {
+        "hapi-capitalize-modules": "1.1.6",
+        "hapi-for-you": "1.0.0",
+        "hapi-no-var": "1.0.1",
+        "hapi-scope-start": "2.1.1",
+        "no-arrowception": "1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.3.tgz",
+      "integrity": "sha512-z7O+bbWRg1eq42SRn7xKrs8XS7997bK8UIJp+kV2cbpwQ2D8stgrF0056IbcciZfdRnuX0RyTyDWNmw+gkcvcg=="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "find-rc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
+      "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+      "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "hapi-capitalize-modules": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
+      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
+      "dev": true
+    },
+    "hapi-for-you": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
+      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
+      "dev": true
+    },
+    "hapi-no-var": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-no-var/-/hapi-no-var-1.0.1.tgz",
+      "integrity": "sha512-kk2xyyTzI+eQ/oA1rO4eVdCpYsrPHVERHa6+mTHD08XXFLaAkkaEs6reMg1VyqGh2o5xPt//DO4EhCacLx/cRA==",
+      "dev": true
+    },
+    "hapi-scope-start": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
+      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.3.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isemail": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
+      "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "joi": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.2.tgz",
+      "integrity": "sha512-bZZSQYW5lPXenOfENvgCBPb9+H6E6MeNWcMtikI04fKphj5tvFL9TOb+H2apJzbCrRw/jebjTH8z6IHLpBytGg==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.3",
+        "isemail": "3.1.1",
+        "topo": "3.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "lab": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-15.4.1.tgz",
+      "integrity": "sha512-A9tM8igxHKisCqxQylbg9R2+yo+MmXAiSuJ7k2lJPuMNCjVd8frMQ7PJu/h5tb1ilybvfGx//oA/mPvRPGyTow==",
+      "dev": true,
+      "requires": {
+        "bossy": "4.0.1",
+        "diff": "3.5.0",
+        "eslint": "4.19.1",
+        "eslint-config-hapi": "11.1.0",
+        "eslint-plugin-hapi": "4.1.0",
+        "espree": "3.5.4",
+        "find-rc": "3.0.1",
+        "handlebars": "4.0.11",
+        "hoek": "5.0.3",
+        "json-stable-stringify": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "mkdirp": "0.5.1",
+        "seedrandom": "2.4.3",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.4",
+        "supports-color": "4.4.0",
+        "will-call": "1.0.1"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "logstash-client": {
       "version": "1.1.1",
@@ -1884,10 +938,214 @@
         "reconnect-net": "0.0.0"
       }
     },
+    "lru-cache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "no-arrowception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
+      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "reconnect-core": {
       "version": "0.0.1",
@@ -1904,6 +1162,306 @@
       "requires": {
         "reconnect-core": "0.0.1"
       }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "seedrandom": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+      "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        }
+      }
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.3"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "will-call": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/will-call/-/will-call-1.0.1.tgz",
+      "integrity": "sha512-1hEeV8SfBYhNRc/bNXeQfyUBX8Dl9SCYME3qXh99iZP9wJcnhnlBsoBw8Y0lXVZ3YuPsoxImTzBiol1ouNR/hg==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,18 +5,15 @@
   "description": "Logstash TCP/UDP broadcasting for Good process monitor",
   "main": "lib/index.js",
   "dependencies": {
-    "fast-safe-stringify": "^1.2.1",
+    "fast-safe-stringify": "^2.0.3",
     "logstash-client": "^1.1.1"
   },
   "devDependencies": {
-    "code": "4.x.x",
-    "lab": "11.x.x"
-  },
-  "peerDependencies": {
-    "good": "7.x.x"
+    "code": "5.x.x",
+    "lab": "15.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This removes the `peerDependencies` on `"good": "7.x.x"` and there should be no code changes necessary. This also brings the `engines` and `devDependencies` inline to match that of `hapi` 17 and updates `fast-safe-stringify` to the latest version.

The lock file also already had the version at `"version": "3.0.0"` and I am unsure why this was. Reinstall reverted this.